### PR TITLE
Fix np.asfarray deprecation

### DIFF
--- a/cosmo_numba/math/integrate/simpson.py
+++ b/cosmo_numba/math/integrate/simpson.py
@@ -88,7 +88,7 @@ def simpson(y, x=None, dx=1.0):
         # use Simpson's rule on first intervals
         result = _basic_simpson(y, 0, N - 3, x, dx)
 
-        h = np.asfarray([dx, dx])
+        h = np.asarray([dx, dx], dtype=np.float64)
         if x is not None:
             # grab the last two spacings from the appropriate axis
             diffs = numbadiff(x)


### PR DESCRIPTION
After updating the software versions in the container I use to run `cosmo_numba`, I ran into this error (abbreviated):

```
File /usr/local/lib/python3.11/site-packages/cosmo_numba/math/integrate/simpson.py:73
AttributeError: `np.asfarray` was removed in the NumPy 2.0 release. Use `np.asarray` with a proper dtype instead.
```

This PR switches the `np.asfarray` call in `simpson.py` to `np.asarray(..., dtype=np.float64)`.

Please let me know what you think!