### PR TITLE
fix: numpy 2.x compatibility for FFTLog

### DIFF
--- a/src/cosmo_numba/math/integrate/fftlog.py
+++ b/src/cosmo_numba/math/integrate/fftlog.py
@@ -245,9 +245,12 @@ def fht(N, k, pk, dim, mu, q_, kcrc, noring):
     prefac_xi = one_over_2pi_dhalf * np.power(r, -dim / 2 - q)
 
     a = np.asarray(prefac_pk * pk + 0.0 * 1j, dtype=np.complex128)
-    b = np.fft.fft(a)
+    # Use objmode for FFT calls - numba doesn't support np.fft with numpy 2.x
+    with nb.objmode(b="complex128[:]"):
+        b = np.fft.fft(a)
     b *= u
-    b = np.fft.ifft(b)
+    with nb.objmode(b="complex128[:]"):
+        b = np.fft.ifft(b)
 
     for n in range(0, int(N / 2)):
         tmp = b[n]


### PR DESCRIPTION
## Summary

- Wrap `np.fft.fft` and `np.fft.ifft` calls in `nb.objmode()` in `fht()` function
- Fixes numba compilation error with numpy 2.x: `Unknown attribute 'fft' of type Module`

## Problem

With numpy 2.x and numba 0.63.1, importing cosmo_numba fails:

```
numba.core.errors.TypingError: Failed in nopython mode pipeline
Unknown attribute 'fft' of type Module(<module 'numpy.fft'...>)
```

This is because numba's nopython mode doesn't support `np.fft.fft` with numpy 2.x.

## Solution

Use `nb.objmode()` to call FFT functions outside nopython mode while keeping the rest of the function JIT-compiled:

```python
with nb.objmode(b="complex128[:]"):
    b = np.fft.fft(a)
```

## Testing

All 29 tests pass with numpy 2.3.5 + numba 0.63.1 + Python 3.12.

🤖 Generated with [Claude Code](https://claude.ai/code)